### PR TITLE
Implement initial Chrome extension scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,26 @@
 # WechatArticle2Strapi
-A chrome extenstion that convert wechat article into strapi cms
+
+A Chrome extension that converts WeChat articles into entries in a Strapi CMS. This project follows the requirements outlined in [`PRD.md`](PRD.md).
+
+## Development
+
+1. Clone the repository.
+2. Run `npm install` if you plan to extend the project with additional tooling.
+3. Load the extension in Chrome:
+   - Open `chrome://extensions`.
+   - Enable Developer mode.
+   - Click "Load unpacked" and select the project folder.
+4. Configure your Strapi endpoint and token in the Options page.
+5. Open a WeChat article and click the extension icon to extract and send the content to Strapi.
+
+## Files
+
+- `manifest.json` – Chrome extension manifest.
+- `src/content.js` – Extracts article content from WeChat pages.
+- `src/background.js` – Handles communication with Strapi.
+- `src/popup.html`/`src/popup.js` – Popup UI for one‑click upload.
+- `src/options.html`/`src/options.js` – Configuration UI for Strapi settings.
+
+## License
+
+MIT

--- a/icons/icon128.png
+++ b/icons/icon128.png
@@ -1,0 +1,1 @@
+placeholder

--- a/icons/icon16.png
+++ b/icons/icon16.png
@@ -1,0 +1,1 @@
+placeholder

--- a/icons/icon48.png
+++ b/icons/icon48.png
@@ -1,0 +1,1 @@
+placeholder

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,30 @@
+{
+  "manifest_version": 3,
+  "name": "WechatArticle2Strapi",
+  "description": "Convert WeChat articles to Strapi CMS entries",
+  "version": "0.1.0",
+  "permissions": [
+    "storage",
+    "activeTab",
+    "scripting"
+  ],
+  "host_permissions": ["<all_urls>"],
+  "background": {
+    "service_worker": "src/background.js"
+  },
+  "action": {
+    "default_popup": "src/popup.html",
+    "default_icon": {
+      "16": "icons/icon16.png",
+      "48": "icons/icon48.png",
+      "128": "icons/icon128.png"
+    }
+  },
+  "options_page": "src/options.html",
+  "content_scripts": [
+    {
+      "matches": ["https://mp.weixin.qq.com/*"],
+      "js": ["src/content.js"]
+    }
+  ]
+}

--- a/src/background.js
+++ b/src/background.js
@@ -1,0 +1,28 @@
+async function sendToStrapi(article) {
+  const config = await chrome.storage.sync.get(['strapiUrl', 'token', 'collection']);
+  const endpoint = `${config.strapiUrl}/api/${config.collection}`;
+
+  const res = await fetch(endpoint, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${config.token}`
+    },
+    body: JSON.stringify({ data: article })
+  });
+
+  if (!res.ok) {
+    throw new Error(`Strapi error: ${res.status}`);
+  }
+
+  return res.json();
+}
+
+chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+  if (msg.type === 'sendToStrapi') {
+    sendToStrapi(msg.article)
+      .then(data => sendResponse({ success: true, data }))
+      .catch(err => sendResponse({ success: false, error: err.message }));
+    return true; // keep channel open
+  }
+});

--- a/src/content.js
+++ b/src/content.js
@@ -1,0 +1,21 @@
+function extractArticle() {
+  const titleEl = document.querySelector('#activity-name') || document.querySelector('h2.rich_media_title');
+  const authorEl = document.querySelector('.rich_media_meta rich_media_meta_text') || document.querySelector('#meta_content span');
+  const publishTimeEl = document.querySelector('#publish_time') || document.querySelector('.rich_media_meta_text');
+  const contentEl = document.querySelector('#js_content');
+  const digestEl = document.querySelector('meta[property="og:description"]');
+
+  return {
+    title: titleEl ? titleEl.innerText.trim() : '',
+    author: authorEl ? authorEl.innerText.trim() : '',
+    publishTime: publishTimeEl ? publishTimeEl.innerText.trim() : '',
+    content: contentEl ? contentEl.innerHTML : '',
+    digest: digestEl ? digestEl.getAttribute('content') : ''
+  };
+}
+
+chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+  if (msg.type === 'extract') {
+    sendResponse(extractArticle());
+  }
+});

--- a/src/options.html
+++ b/src/options.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html>
+<head>
+  <title>Options - WechatArticle2Strapi</title>
+  <script src="options.js"></script>
+</head>
+<body>
+  <label>Strapi URL: <input id="strapiUrl" type="text" /></label><br />
+  <label>Collection: <input id="collection" type="text" /></label><br />
+  <label>Token: <input id="token" type="password" /></label><br />
+  <button id="save">Save</button>
+  <div id="status"></div>
+</body>
+</html>

--- a/src/options.js
+++ b/src/options.js
@@ -1,0 +1,22 @@
+function load() {
+  chrome.storage.sync.get(['strapiUrl', 'token', 'collection'], data => {
+    document.getElementById('strapiUrl').value = data.strapiUrl || '';
+    document.getElementById('token').value = data.token || '';
+    document.getElementById('collection').value = data.collection || '';
+  });
+}
+
+function save() {
+  const data = {
+    strapiUrl: document.getElementById('strapiUrl').value,
+    token: document.getElementById('token').value,
+    collection: document.getElementById('collection').value
+  };
+  chrome.storage.sync.set(data, () => {
+    document.getElementById('status').textContent = 'Saved';
+  });
+}
+
+document.getElementById('save').addEventListener('click', save);
+
+document.addEventListener('DOMContentLoaded', load);

--- a/src/popup.html
+++ b/src/popup.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html>
+<head>
+  <title>WechatArticle2Strapi</title>
+  <script src="popup.js"></script>
+  <style>
+    body{width:200px;padding:10px;font-family:sans-serif;}
+    button{width:100%;padding:8px;margin-top:10px;}
+  </style>
+</head>
+<body>
+  <button id="extract">Extract & Send</button>
+  <div id="status"></div>
+</body>
+</html>

--- a/src/popup.js
+++ b/src/popup.js
@@ -1,0 +1,18 @@
+document.getElementById('extract').addEventListener('click', () => {
+  document.getElementById('status').textContent = 'Extracting...';
+  chrome.tabs.query({ active: true, currentWindow: true }, tabs => {
+    chrome.tabs.sendMessage(tabs[0].id, { type: 'extract' }, article => {
+      if (!article) {
+        document.getElementById('status').textContent = 'Extraction failed';
+        return;
+      }
+      chrome.runtime.sendMessage({ type: 'sendToStrapi', article }, response => {
+        if (response && response.success) {
+          document.getElementById('status').textContent = 'Upload success';
+        } else {
+          document.getElementById('status').textContent = 'Upload failed: ' + (response && response.error);
+        }
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add manifest and extension scripts per PRD specs
- implement content script to scrape WeChat article
- add background script to send data to Strapi
- create popup and options pages for user interaction
- document usage in README

## Testing
- `git status --short`
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684178c938dc8332a7a42c2acececab5